### PR TITLE
Fix Arrow Character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Initializes a new instance of the Validator class.
 
 <br/>
 
-**`validate(self, value, metadata={}) → ValidationResult`**
+**`validate(self, value, metadata={}) -> ValidationResult`**
 
 <ul>
 


### PR DESCRIPTION
Previously the README for this validator contained the `→` character which is not supported in the standard character-set python uses internally for Windows.  In general this should be `->` anyway because it should represent the typing syntax we use in python.