### PR TITLE
[bug] Pin unpinned dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
-    "presidio-analyzer",
-    "presidio-anonymizer",
+    "presidio-analyzer==2.2.354",
+    "presidio-anonymizer==2.2.354",
+    "numpy==1.26.4",
+    "spacy==3.7.4",
     "guardrails-ai>=0.4.0"
 ]
 
@@ -30,3 +32,4 @@ testpaths = [
 
 [tool.pyright]
 include = ["validator"]
+


### PR DESCRIPTION
On 2024/06/16, numpy released 2.0.0.  Congratulations to them.  Some child dependencies of the PII detector did not pin dependencies, thus leading to the following error on install:

```
guardrails hub install hub://guardrails/detect_pii
Installing hub://guardrails/detect_pii...
[=   ] Downloading dependencies  Running command git clone --filter=blob:none --quiet https://github.com/guardrails-ai/detect_pii.git /private/var/folders/99/9myytxhs0kd2bx81qgc4bl0c0000gn/T/pip-req-build-qdso3or7
[====] Running post-install setupTraceback (most recent call last):
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/guardrails/hub/guardrails/detect_pii/validator/post-install.py", line 1, in <module>
    from presidio_analyzer import AnalyzerEngine
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/presidio_analyzer/__init__.py", line 9, in <module>
    from presidio_analyzer.entity_recognizer import EntityRecognizer
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/presidio_analyzer/entity_recognizer.py", line 6, in <module>
    from presidio_analyzer.nlp_engine import NlpArtifacts
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/presidio_analyzer/nlp_engine/__init__.py", line 4, in <module>
    from .nlp_artifacts import NlpArtifacts
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/presidio_analyzer/nlp_engine/nlp_artifacts.py", line 4, in <module>
    from spacy.tokens import Doc, Span
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/spacy/__init__.py", line 6, in <module>
    from .errors import setup_default_warnings
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/spacy/errors.py", line 3, in <module>
    from .compat import Literal
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/spacy/compat.py", line 39, in <module>
    from thinc.api import Optimizer  # noqa: F401
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/thinc/api.py", line 1, in <module>
    from .backends import (
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/thinc/backends/__init__.py", line 17, in <module>
    from .cupy_ops import CupyOps
  File "/Users/josephcatrambone/.virtualenvs/debug_detect_pii/lib/python3.10/site-packages/thinc/backends/cupy_ops.py", line 16, in <module>
    from .numpy_ops import NumpyOps
  File "thinc/backends/numpy_ops.pyx", line 1, in init thinc.backends.numpy_ops
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
Failed to run post install script for guardrails/detect_pii
Exit code: 1
stdout: b''
```

It is a known error on presidio: https://github.com/microsoft/presidio/issues/1400

This works around the issue.