### PR TITLE
Make nltk explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "presidio-analyzer~=2.2",
     "presidio-anonymizer~=2.2",
     "numpy<2.0.0",
-    "guardrails-ai>=0.4.0"
+    "guardrails-ai>=0.4.0",
+    "nltk>3.0,<=3.8.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Due to the pending removal of `nltk` from the core package we will need this to be an explicit dependency